### PR TITLE
Fix navigation between getting started and types page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+next:
+  text: 'Types'
+  link: '/docs/types'
+---
 
 # Getting started
 


### PR DESCRIPTION
Fix next page link on Getting Started documentation

Add frontmatter metadata to specify Types as the next page when viewing the Getting Started guide, fixing the navigation flow in the documentation.

Before
<img width="1092" alt="before" src="https://github.com/user-attachments/assets/380139f6-fdb6-4dad-a18c-ed0ed048de66">

After
<img width="1092" alt="before" src="https://github.com/user-attachments/assets/ffb91f63-7c1a-4135-b48a-a85124aadb84">
