### PR TITLE
spelling adjustment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # Introduction
 
-Literal provides a set of tools to help you write more expressive, confident Ruby, reduce your error rate and get more milage out of your existing tests by validating input.
+Literal provides a set of tools to help you write more expressive, confident Ruby, reduce your error rate and get more mileage out of your existing tests by validating input.


### PR DESCRIPTION
I can't 100% say this is a correction, but I'm pretty sure that "mileage" is preferred in both British and American English.  

The Cambridge English Dictionary only lists "milage" in the American section, but I've personally never seen this spelling before, so if it's used here then it's very rare.

https://dictionary.cambridge.org/dictionary/english/mileage?q=milage