### PR TITLE
document passing arguments

### DIFF
--- a/docs/built-in-types.md
+++ b/docs/built-in-types.md
@@ -54,6 +54,12 @@ This, for example, will check that the object is a `Person`, then it will call `
 _Constraint(Person, name: String)
 ```
 
+You can also pass arguments:
+
+```ruby
+_String(_Constraint(start_with?: "/"))
+```
+
 ## `_Constraint?(*T, **K)`
 
 `_Nilable(_Constraint?(*T, **K))`.


### PR DESCRIPTION
I learned in Discord today that it's possible to pass arguments to the methods called by `_Constraint`. I had assumed this was a limitation because there aren't any examples of it in the docs.