### PR TITLE
Fix possible typo in docs

### DIFF
--- a/docs/built-in-types.md
+++ b/docs/built-in-types.md
@@ -56,7 +56,7 @@ _Constraint(Person, name: String)
 
 ## `_Constraint?(*T, **K)`
 
-`_Nilable(_Constraint?(*T, **K))`.
+`_Nilable(_Constraint(*T, **K))`.
 
 ## `_Date(*T, **K)`
 


### PR DESCRIPTION
This pull request includes a minor correction in the documentation for built-in types. Specifically, it fixes the description of `_Constraint?` to remove an possibly unwanted question mark in the type signature.